### PR TITLE
example: show serialized record

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -24,6 +24,9 @@
 
 """Minimal Flask application example.
 
+Note that Microsoft Edge and Internet Explorer don't display this example
+properly.
+
 First install Invenio-PIDRelations, setup the application and load
 fixture data by running:
 
@@ -46,6 +49,13 @@ and open the example application in your browser:
 .. code-block:: console
 
     $ open http://127.0.0.1:5000/
+
+This example lets you create dummy records and link them as "versions" of
+a same parent Persistent Identifier (also named PID). The left panel list all
+the parent PIDs with their "child" versions.
+
+The output of a serialized relation is also visible by clicking on any of the
+versions.
 
 To reset the example application run:
 
@@ -95,7 +105,12 @@ record_resolver = Resolver(
 
 
 class SimpleRecordSchema(Schema, PIDRelationsMixin):
-    """Tiny schema for our simple record."""
+    """Tiny schema for our simple record.
+
+    This serializer also serializes the relations as it inherits
+    PIDRelationsMixin. The result can be seen in the view by clicking on a
+    version of a record.
+    """
 
     recid = fields.Str()
     title = fields.Str()

--- a/examples/index.html
+++ b/examples/index.html
@@ -73,7 +73,16 @@ body {
             {% set pid_versioning = head | to_versioning_api(child=False) %}
             {% for child in pid_versioning.children %}
               {% set record = child | to_record %}
-              <li>[{{ child.pid_value }}] - {{ record['title'] }} <br/> <small>{{ record['body'] }}</small></li>
+              <li>
+                  <details>
+                      <summary>
+                          [{{ child.pid_value }}] - {{ record['title'] }} <br/> <small>{{ record['body'] }}</small>
+                      </summary>
+                      <!-- Show what output of our serializer looks like -->
+                      <b>Serialized record:</b>
+                      <p style="white-space: pre-wrap; margin: 0px;">{{ record|tojson(indent=4)|safe}}</p>
+                  </details>
+              </li>
             {% endfor %}
             </ul>
           </li>


### PR DESCRIPTION
* Adds a serialized version of each record to the example view.
  This shows the output of the relation serializer.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>