### PR TITLE
api: show connected pids with the same relation

### DIFF
--- a/invenio_pidrelations/api.py
+++ b/invenio_pidrelations/api.py
@@ -29,6 +29,7 @@ from __future__ import absolute_import, print_function
 from flask_sqlalchemy import BaseQuery
 from invenio_db import db
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
+from sqlalchemy import and_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import aliased
 from werkzeug.utils import cached_property
@@ -148,7 +149,10 @@ class PIDNode(object):
             [to_pid], db.session(), _filtered_pid_class=to_pid
         ).join(
             PIDRelation,
-            to_pid.id == to_relation
+            and_(
+                to_pid.id == to_relation,
+                PIDRelation.relation_type == self.relation_type.id
+            )
         )
         # accept both PersistentIdentifier models and fake PIDs with just
         # pid_value, pid_type as they are fetched with the PID fetcher.

--- a/invenio_pidrelations/models.py
+++ b/invenio_pidrelations/models.py
@@ -36,6 +36,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import backref
 from sqlalchemy_utils.models import Timestamp
 
+from invenio_pidrelations.errors import PIDRelationConsistencyError
+
 _ = make_lazy_gettext(lambda: gettext)
 
 logger = logging.getLogger('invenio-pidrelations')
@@ -113,7 +115,7 @@ class PIDRelation(db.Model, Timestamp):
                           index=index)
                 db.session.add(obj)
         except IntegrityError:
-            raise Exception("PID Relation already exists.")
+            raise PIDRelationConsistencyError("PID Relation already exists.")
             # msg = "PIDRelation already exists: " \
             #       "{0} -> {1} ({2})".format(
             #         parent_pid, child_pid, relation_type)

--- a/setup.py
+++ b/setup.py
@@ -88,11 +88,13 @@ setup_requires = [
 
 install_requires = [
     'Flask-BabelEx>=0.9.2',
+    'Flask-OAuthlib>=0.9.3,<0.9.4',
     'invenio-pidstore>=1.0.0b1',
     'invenio-rest[cors]>=1.0.0a10',
     'SQLAlchemy>=1.0.9',
-    'marshmallow>=2.12.2',
-    'six>=1.10',
+    'marshmallow>=2.15.2',
+    'requests-oauthlib>=0.5.0,<1.2.0',
+    'six>=1.11',
 ]
 
 packages = find_packages()

--- a/setup.py
+++ b/setup.py
@@ -48,13 +48,13 @@ extras_require = {
     ],
     'tests': tests_require,
     'mysql': [
-        'invenio-db[mysql,versioning]>=1.0.0b3',
+        'invenio-db[mysql,versioning]>=1.0.0',
     ],
     'postgresql': [
-        'invenio-db[postgresql,versioning]>=1.0.0b3',
+        'invenio-db[postgresql,versioning]>=1.0.0',
     ],
     'sqlite': [
-        'invenio-db[versioning]>=1.0.0b3',
+        'invenio-db[versioning]>=1.0.0',
     ],
     'records': [
         'invenio-deposit>=1.0.0a7',
@@ -63,10 +63,10 @@ extras_require = {
         # recursively lowest dependencies.
         'invenio-records-ui>=1.0.0a8',
         'invenio-records-rest>=1.0.0a17',
-        'invenio-accounts>=1.0.0b5',
+        'invenio-accounts>=1.0.0b7',
         'Flask-WTF>=0.13.1',
         # Needed in order to have correct alembic upgrade.
-        'invenio-oauth2server>=1.0.0a14',
+        'invenio-oauth2server>=1.0.0b4',
         'invenio-records-files>=1.0.0a9',
         'invenio-files-rest>=1.0.0a15',
     ],
@@ -87,14 +87,18 @@ setup_requires = [
 ]
 
 install_requires = [
-    'Flask-BabelEx>=0.9.2',
-#    'Flask-OAuthlib>=0.9.3,<0.9.4',
-    'invenio-pidstore>=1.0.0b1',
-    'invenio-rest[cors]>=1.0.0a10',
+    'Flask-BabelEx>=0.9.3',
+    'flask-oauthlib>=0.9.4',
+    'invenio-pidstore>=1.0.0',
+    'invenio-rest[cors]>=1.0.0',
     'SQLAlchemy>=1.0.9',
     'marshmallow>=2.15.2',
-    'requests-oauthlib>=0.5.0,<1.2.0',
-    'six>=1.10',
+    'requests-oauthlib>=1.1.0,<1.2.0',
+    'oauthlib<3.0.0,>=2.1.0',
+    'six>=1.11',
+    'urllib3<1.25,>=1.21.1',
+    'idna<2.8,>=2.5',
+    'SQLAlchemy-Continuum>=1.3,<1.3.5',
 ]
 
 packages = find_packages()

--- a/setup.py
+++ b/setup.py
@@ -88,13 +88,13 @@ setup_requires = [
 
 install_requires = [
     'Flask-BabelEx>=0.9.2',
-    'Flask-OAuthlib>=0.9.3,<0.9.4',
+#    'Flask-OAuthlib>=0.9.3,<0.9.4',
     'invenio-pidstore>=1.0.0b1',
     'invenio-rest[cors]>=1.0.0a10',
     'SQLAlchemy>=1.0.9',
     'marshmallow>=2.15.2',
     'requests-oauthlib>=0.5.0,<1.2.0',
-    'six>=1.11',
+    'six>=1.10',
 ]
 
 packages = find_packages()

--- a/tests/test_helpers/__init__.py
+++ b/tests/test_helpers/__init__.py
@@ -24,12 +24,12 @@
 
 """Test helpers."""
 
-from marshmallow import Schema, fields
 import pytest
-
-from invenio_pidstore.models import PIDStatus, PersistentIdentifier
 from invenio_pidstore.fetchers import FetchedPID
+from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 from invenio_pidstore.providers.recordid import RecordIdProvider
+from marshmallow import Schema, fields
+
 from invenio_pidrelations.serializers.utils import serialize_relations
 
 


### PR DESCRIPTION
Fixes so that a `PIDNode` only returns `parents` and `children` belonging to the same `relation_type`.